### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: go test -v ./...
     
     - name: Publish to Github Packages Registry
-      uses: elgohr/Publish-Docker-Github-Action@5d8ac99
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: efontan/docean-deploy/docean-deploy
         registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore